### PR TITLE
Added support for zoo/xts time-series as input

### DIFF
--- a/R/deflate.R
+++ b/R/deflate.R
@@ -38,6 +38,12 @@
 
 deflate <- function(nominal_values, nominal_dates, real_date, index = c("ipca", "igpm", "igpdi", "ipc", "inpc")){
 
+  # Parse zoo/xts input
+  if ("zoo" %in% rownames(installed.packages()) && zoo::is.zoo(nominal_values)) {
+    nominal_dates <- zoo::index(nominal_values)
+    nominal_values <- zoo::coredata(nominal_values)
+  }
+
 
   # Inputs
   real_date <- clean_real_date(real_date)


### PR DESCRIPTION
A maioria dos pacotes que trabalham com dados financeiros geralmente aceitam séries temporais dos pacotes `zoo` e `xts` como entrada. Adicionei uma checagem adicional para poder permitir trabalhar com esse objetos.

Se achar que isso é válido, precisa atualizar a documentação e pensar se a função `deflate` deve retornar um objeto desse tipo (`zoo` ou `xts`) quando a entrada for desse tipo.